### PR TITLE
feat: hide blog link if page not created

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -2,4 +2,6 @@
 {{ range .Site.Menus.main }}
 <a href="{{ .URL }}">{{ .Name }}</a>
 {{ end }}
+{{ with .Site.GetPage "/blog" }}
 <a href="{{ "/blog" | relURL }}">Blog</a>
+{{ end }}


### PR DESCRIPTION
allows this theme to be used for sites that don't have a blog.