### PR TITLE
Prevent adjustments of font size after orientation changes in iOS.

### DIFF
--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -1,4 +1,7 @@
 <style>
+  html {
+    -webkit-text-size-adjust: 100%;
+  }
   body {
     font-family: Verdana, sans-serif;
     margin: auto;


### PR DESCRIPTION
The font size increases on iOS when viewing in landscape (while I usually use that to see wider lines). This fixes that. Adopted from normalize.css.

In general: it might be worthwhile to adopt normalise.css or similar more broadly to improve compatibility and behaviour consistency.