### PR TITLE
Ensure images are always shown in original proportion when resized

### DIFF
--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -60,6 +60,7 @@
 
   img {
     max-width: 100%;
+    height: auto;
   }
 
   code {


### PR DESCRIPTION
`max-width` works fine, but breaks proportionality sometimes (on my Apple devices in any case).

From https://stackoverflow.com/questions/8336448/how-can-i-proportionally-scale-images-to-max-width