### PR TITLE
Don't interfere with Chroma's highlighting

### DIFF
--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -75,6 +75,11 @@
     font-size: 14px;
   }
 
+  div.highlight code {
+    background-color: unset;
+    color: initial;
+  }
+
   blockquote {
     border-left: 1px solid #999;
     color: #222;


### PR DESCRIPTION
Chroma sets `color` and `background-color` directly on a `<pre>` element under a `<div class="highlight">` but the theme was interfering with those color settings from both the `code` and `pre code` selectors. Since Chroma highlighting is under a `highlight` class we can let CSS choose whatever is set explicitly (`initial`) on the `<pre>` element, and `unset` the colors that are set by the `code` selector elsewhere, so that under a `<code>` element that's under a `<div class="highlight">` it will just inherit from the `<pre>` above it where Chroma sets all it's colors.

That's a sort of long winded way of saying that I think I've fixed the color interference problem in a way that won't mess with anything else in the theme. I've tested this on a wide selection of Chroma styles, with both light and dark color schemes and it seems to work correctly in all cases. Which is to say that Chroma appears to have full control of both `color` and `background-color` for code blocks that it's highlighting.

Fixes #19