### PR TITLE
feat: enable optional custom date format

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -42,3 +42,10 @@ ignoreErrors = ["error-disable-taxonomy"]
   # This theme will, by default, inject a made-with-line at the bottom of the page.
   # You can turn it off, but we would really appreciate if you don’t :-).
   # hideMadeWithLine = true
+
+  # By default, this theme displays dates with a format like "02 Jan, 2006", but
+  # you can customize it by setting the `dateFormat` param in your site's config
+  # file. See [Hugo's Format function docs](https://gohugo.io/functions/format/)
+  # for details. An example TOML config that uses [ISO
+  # 8601](https://en.wikipedia.org/wiki/ISO_8601) format:
+  # dateFormat = "2006-01-02"

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -12,7 +12,7 @@
       <span>
         <i>
           <time datetime='{{ .Date.Format "2006-01-02" }}' pubdate>
-            {{ .Date.Format "02 Jan, 2006" }}
+            {{ .Date.Format (default "02 Jan, 2006" .Site.Params.dateFormat) }}
           </time>
         </i>
       </span>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,7 +4,7 @@
 <p>
   <i>
     <time datetime='{{ .Date.Format "2006-01-02" }}' pubdate>
-      {{ .Date.Format "02 Jan, 2006" }}
+      {{ .Date.Format (default "02 Jan, 2006" .Site.Params.dateFormat) }}
     </time>
   </i>
 </p>


### PR DESCRIPTION
Adds a .Site.Params.dateFormat setting to let users specify a Hugo-style
date format string for content. Previously, the date format was
hardcoded to "02 Jan, 2006", presumably to match the original BearBlog
style. This format gets used by default if the new "dateFormat" setting
is absent from the site config.