### PR TITLE
Fix a remaining issue with b8c8871 (#20)

### DIFF
--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -75,9 +75,14 @@
     font-size: 14px;
   }
 
+  div.highlight pre {
+    background-color: initial;
+    color: initial;
+  }
+
   div.highlight code {
     background-color: unset;
-    color: initial;
+    color: unset;
   }
 
   blockquote {


### PR DESCRIPTION
It turns out my original proposal for #20 was correct, but not for the reasons I thought. We need to set both `background-color` and `color` to `initial` on `div.highlight pre` because that's where Chroma sets those colors (including the default `color` if configured). Setting to `initial` there makes it so that if the selected style *doesn't* configure a default color, we'll use the `initial` color, which is going to be the right choice because the reason style author left that unset because they didn't consider dark color schemes messing with their style. Then we `unset` the colors on `div.highlight code` because otherwise the `code` colors from the theme will override the colors that would otherwise be inherited from Chroma's `<pre>` element.

Stricly speaking I can't say that setting `background-color` to `initial` is required, because I haven't found a Chroma style that *doesn't* set a `background-color`, but I figure it's possible (at least for a light theme) and it makes sense to fix it just in case, and causes no harm otherwise.

Here's a screenshot of what the dark style `native` looks like with the previous commit with a dark color scheme:
![image](https://user-images.githubusercontent.com/260569/115122350-4baf5c00-9f6c-11eb-8360-88079a3fb859.png)

I tried to find a simpler, less invasive, way to do this but at this point I'm pretty confident (again) that this is both actually correct *and* still makes sense.

Let me know if you don't agree though, I'm happy to keep working on it until it makes sense to both of us - especially if I'm wrong. 😄