### PR TITLE
Use `overflow-x: auto` to avoid spilling long lines

### DIFF
--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -73,6 +73,7 @@
     padding: 20px;
     white-space: pre-wrap;
     font-size: 14px;
+    overflow-x: auto;
   }
 
   div.highlight pre {


### PR DESCRIPTION
A few days ago Google notified me of a "content wider than screen" mobile usability issue. Sure enough, with the latest release of Chrome, one of my pages spills some very long lines of XML way off to the right of the screen.

![Screenshot 2022-05-28 6 36 17 PM](https://user-images.githubusercontent.com/260569/170848427-a31dbbaf-51f3-4e60-976c-6e1c9d0d7c97.png)

This commit fixes the issue, without messing with anything that actually fits in the content area, by setting [`overflow-x`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-x) to `auto` for `pre` and `code`. It adds a scrollbar, but only if one is needed, so that the full page width is as expected / defined rather than overflowed when there's extra content in a non-wrapped context.