### PR TITLE
Fill out code for pubdate, Add indicator for draft posts

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -11,12 +11,12 @@
     <li>
       <span>
         <i>
-          <time datetime='{{ .Date.Format "2006-01-02" }}' pubdate>
+          <time datetime='{{ .Date.Format "2006-01-02" }}' pubdate='{{ .PublishDate.Format "2006-01-02" }}'>
             {{ .Date.Format (default "02 Jan, 2006" .Site.Params.dateFormat) }}
           </time>
         </i>
       </span>
-      <a href="{{ .Permalink }}">{{ .Title }}</a>
+      <a href="{{ .Permalink }}">{{ .Title }}{{ if .Draft }}*{{ end }}</a>
     </li>
     {{ else }}
     <li>


### PR DESCRIPTION
I noticed the `<time>` tags for posts have an empty field for pubdate, so I filled that out with the PubDate page method.

The second change is more opinionated, but I'd like an indicator as to which of my posts are drafts , and this was a quick and dirty solution. If needed, this could be a class, or just omitted entirely.