### PR TITLE
Remove hardcoded blog from nav.html

### DIFF
--- a/exampleSite/content/bear.md
+++ b/exampleSite/content/bear.md
@@ -1,7 +1,7 @@
 +++
 title = "Bear"
 menu = "main"
-weight = "20"
+weight = 20
 +++
 
 # Bear

--- a/exampleSite/content/blog/_index.md
+++ b/exampleSite/content/blog/_index.md
@@ -1,3 +1,4 @@
 +++
 title = "Blog"
+menu = "main"
 +++

--- a/exampleSite/content/blog/_index.md
+++ b/exampleSite/content/blog/_index.md
@@ -1,4 +1,5 @@
 +++
 title = "Blog"
 menu = "main"
+weight = 100
 +++

--- a/exampleSite/content/hugo.md
+++ b/exampleSite/content/hugo.md
@@ -1,7 +1,7 @@
 +++
 title = "Hugo"
 menu = "main"
-weight = "10"
+weight = 10
 +++
 
 # Hugo

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -6,7 +6,7 @@
     <a href="{{ "blog" | relURL }}">Remove filter</a>
   </small>
   {{ end }}
-  <ul class="blog-posts">
+  <ul class="posts">
     {{ range .Pages }}
     <li>
       <span>
@@ -24,8 +24,7 @@
     </li>
     {{ end }}
   </ul>
-  {{ if .Data.Singular }}
-  {{else}}
+    {{ if not .Data.Singular }}
     <small>
       <div>
         {{ range .Site.Taxonomies.tags }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -6,7 +6,7 @@
     <a href="{{ "blog" | relURL }}">Remove filter</a>
   </small>
   {{ end }}
-  <ul class="posts">
+  <ul class="blog-posts">
     {{ range .Pages }}
     <li>
       <span>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -24,14 +24,14 @@
     </li>
     {{ end }}
   </ul>
-    {{ if not .Data.Singular }}
-    <small>
-      <div>
-        {{ range .Site.Taxonomies.tags }}
-        <a href="{{ .Page.Permalink }}">#{{ .Page.Title }}</a>&nbsp;
-        {{ end }}
-      </div>
-    </small>
-    {{ end }}
+  {{ if not .Data.Singular }}
+  <small>
+    <div>
+      {{ range .Site.Taxonomies.tags }}
+      <a href="{{ .Page.Permalink }}">#{{ .Page.Title }}</a>&nbsp;
+      {{ end }}
+    </div>
+  </small>
+  {{ end }}
 </content>
 {{ end }}

--- a/layouts/partials/custom_body.html
+++ b/layouts/partials/custom_body.html
@@ -1,3 +1,3 @@
-  <!-- A partial to be overwritten by the user.
+<!-- A partial to be overwritten by the user.
   Simply place a custom_body.html into
   your local /layouts/partials-directory -->

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -2,6 +2,3 @@
 {{ range .Site.Menus.main }}
 <a href="{{ .URL }}">{{ .Name }}</a>
 {{ end }}
-{{ with .Site.GetPage "/blog" }}
-<a href="{{ "blog" | relURL }}">Blog</a>
-{{ end }}

--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -140,7 +140,7 @@
       padding: unset;
   }
 
-  ul.posts li {
+  ul.blog-posts li {
       display: flex;
   }
 

--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -144,7 +144,7 @@
       display: flex;
   }
 
-  ul.posts li span {
+  ul.blog-posts li span {
       flex: 0 0 130px;
   }
 

--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -128,21 +128,21 @@
       overflow-x: auto;
   }
 
-  /* blog post list */
-  ul.blog-posts {
+  /* post list */
+  ul.posts {
       list-style-type: none;
       padding: unset;
   }
 
-  ul.blog-posts li {
+  ul.posts li {
       display: flex;
   }
 
-  ul.blog-posts li span {
+  ul.posts li span {
       flex: 0 0 130px;
   }
 
-  ul.blog-posts li a:visited {
+  ul.posts li a:visited {
       color: var(--visited-color);
   }
 </style>

--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -134,7 +134,7 @@
       overflow-x: auto;
   }
 
-  /* post list */
+  /* blog post list */
   ul.blog-posts {
       list-style-type: none;
       padding: unset;

--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -148,7 +148,7 @@
       flex: 0 0 130px;
   }
 
-  ul.posts li a:visited {
+  ul.blog-posts li a:visited {
       color: var(--visited-color);
   }
 </style>

--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -135,7 +135,7 @@
   }
 
   /* post list */
-  ul.posts {
+  ul.blog-posts {
       list-style-type: none;
       padding: unset;
   }

--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -1,154 +1,162 @@
 <style>
   :root {
-      --width: 720px;
-      --font-main: Verdana, sans-serif;
-      --font-secondary: Verdana, sans-serif;
-      --font-scale: 1em;
-      --background-color: #fff;
-      --heading-color: #222;
-      --text-color: #444;
-      --link-color: #3273dc;
-      --visited-color:  #8b6fcb;
-      --code-background-color: #f2f2f2;
-      --code-color: #222;
-      --blockquote-color: #222;
+    --width: 720px;
+    --font-main: Verdana, sans-serif;
+    --font-secondary: Verdana, sans-serif;
+    --font-scale: 1em;
+    --background-color: #fff;
+    --heading-color: #222;
+    --text-color: #444;
+    --link-color: #3273dc;
+    --visited-color: #8b6fcb;
+    --code-background-color: #f2f2f2;
+    --code-color: #222;
+    --blockquote-color: #222;
   }
 
   @media (prefers-color-scheme: dark) {
-      :root {
-          --background-color: #01242e;
-          --heading-color: #eee;
-          --text-color: #ddd;
-          --link-color: #8cc2dd;
-          --visited-color:  #8b6fcb;
-          --code-background-color: #000;
-          --code-color: #ddd;
-          --blockquote-color: #ccc;
-      }
+    :root {
+      --background-color: #01242e;
+      --heading-color: #eee;
+      --text-color: #ddd;
+      --link-color: #8cc2dd;
+      --visited-color: #8b6fcb;
+      --code-background-color: #000;
+      --code-color: #ddd;
+      --blockquote-color: #ccc;
+    }
   }
 
   body {
-      font-family: var(--font-secondary);
-      font-size: var(--font-scale);
-      margin: auto;
-      padding: 20px;
-      max-width: var(--width);
-      text-align: left;
-      background-color: var(--background-color);
-      word-wrap: break-word;
-      overflow-wrap: break-word;
-      line-height: 1.5;
-      color: var(--text-color);
+    font-family: var(--font-secondary);
+    font-size: var(--font-scale);
+    margin: auto;
+    padding: 20px;
+    max-width: var(--width);
+    text-align: left;
+    background-color: var(--background-color);
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    line-height: 1.5;
+    color: var(--text-color);
   }
 
-  h1, h2, h3, h4, h5, h6 {
-      font-family: var(--font-main);
-      color: var(--heading-color);
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: var(--font-main);
+    color: var(--heading-color);
   }
 
   a {
-      color: var(--link-color);
-      cursor: pointer;
-      text-decoration: none;
+    color: var(--link-color);
+    cursor: pointer;
+    text-decoration: none;
   }
 
   a:hover {
-      text-decoration: underline;
+    text-decoration: underline;
   }
 
   nav a {
-      margin-right: 8px;
+    margin-right: 8px;
   }
 
-  strong, b {
-      color: var(--heading-color);
+  strong,
+  b {
+    color: var(--heading-color);
   }
 
   button {
-      margin: 0;
-      cursor: pointer;
+    margin: 0;
+    cursor: pointer;
   }
 
   time {
-   	font-family: monospace;
-    	font-style: normal;
-    	font-size: 15px;
+    font-family: monospace;
+    font-style: normal;
+    font-size: 15px;
   }
 
   main {
-      line-height: 1.6;
+    line-height: 1.6;
   }
 
   table {
-      width: 100%;
+    width: 100%;
   }
 
   hr {
-      border: 0;
-      border-top: 1px dashed;
+    border: 0;
+    border-top: 1px dashed;
   }
 
   img {
-      max-width: 100%;
+    max-width: 100%;
   }
 
   code {
-      font-family: monospace;
-      padding: 2px;
-      background-color: var(--code-background-color);
-      color: var(--code-color);
-      border-radius: 3px;
+    font-family: monospace;
+    padding: 2px;
+    background-color: var(--code-background-color);
+    color: var(--code-color);
+    border-radius: 3px;
   }
 
   blockquote {
-      border-left: 1px solid #999;
-      color: var(--code-color);
-      padding-left: 20px;
-      font-style: italic;
+    border-left: 1px solid #999;
+    color: var(--code-color);
+    padding-left: 20px;
+    font-style: italic;
   }
 
   footer {
-      padding: 25px 0;
-      text-align: center;
+    padding: 25px 0;
+    text-align: center;
   }
 
   .title:hover {
-      text-decoration: none;
+    text-decoration: none;
   }
 
   .title h1 {
-      font-size: 1.5em;
+    font-size: 1.5em;
   }
 
   .inline {
-      width: auto !important;
+    width: auto !important;
   }
 
-  .highlight, .code {
-      padding: 1px 15px;
-      background-color: var(--code-background-color);
-      color: var(--code-color);
-      border-radius: 3px;
-      margin-block-start: 1em;
-      margin-block-end: 1em;
-      overflow-x: auto;
+  .highlight,
+  .code {
+    padding: 1px 15px;
+    background-color: var(--code-background-color);
+    color: var(--code-color);
+    border-radius: 3px;
+    margin-block-start: 1em;
+    margin-block-end: 1em;
+    overflow-x: auto;
   }
 
   /* blog post list */
   ul.blog-posts {
-      list-style-type: none;
-      padding: unset;
+    list-style-type: none;
+    padding: unset;
   }
 
   ul.blog-posts li {
-      display: flex;
+    display: flex;
   }
 
   ul.blog-posts li span {
-      flex: 0 0 130px;
+    flex: 0 0 130px;
   }
 
   ul.blog-posts li a:visited {
-      color: var(--visited-color);
+    color: var(--visited-color);
   }
+
 </style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "hugo-bearblog",
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {


### PR DESCRIPTION
- Remove `/blog` from `nav.html`
- Formatting fixes

Consider:
- Would be nice if we could generalize `list.html` to support any directory. At the moment, it currently has `/blog` hardcoded to remove tag filter.