### PR TITLE
Allow setting hideMadeWithLine per page

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,1 +1,1 @@
-{{ if ne .Site.Params.hideMadeWithLine true }}Made with <a href="https://github.com/janraasch/hugo-bearblog/">Hugo ʕ•ᴥ•ʔ Bear</a>{{ end }}
+{{ if not (.Param "hideMadeWithLine") }}Made with <a href="https://github.com/janraasch/hugo-bearblog/">Hugo ʕ•ᴥ•ʔ Bear</a>{{ end }}


### PR DESCRIPTION
The "Made With" footer used to look at the site-wide configuration. This change allows overriding the site-wide configuration to show or hide it on a page-by-page basis.

As I am starting a new site, the footer made it feel a bit cluttered: 2-3 lines of content, plus one line of footer. I wanted to disable it on most pages, but leave it enabled on a few pages for now.

The opposite is also now possible with this change: leave enabled everywhere but on a few pages.

I made sure to check that it is still enabled by default if the setting is not present.