### PR TITLE
Add Post Navigator setting for Blog Posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,21 @@ For more information, read the official [setup guide][hugo-setup-guide] of Hugo.
 
 Please check out the [hugo.toml](https://github.com/janraasch/hugo-bearblog/blob/master/exampleSite/hugo.toml) included in the [exampleSite](https://github.com/janraasch/hugo-bearblog/tree/master/exampleSite) of this theme.
 
+### Post Navigation Setting
+
+In case the user ends up reading more than one blog post, in order to read another they have
+to go to the `/blog` page.
+
+By enabling, in `hugo.toml`:
+
+```toml
+[params]
+    enablePostNavigator = true
+```
+
+It adds a navigator, at the end of the blog post content, so that the user can go to the next
+or previous post.
+
 ## Content & structure
 
 ### Starting fresh
@@ -64,6 +79,7 @@ hugo new blog/my-new-post.md
 
 Add a `custom_head.html`-file to your `layouts/partials`-directory. In there you may add a `<style>`-tag, *or* you may add a `<link>`-tag referencing your own `custom.css` (in case you prefer to have a separate `.css`-file). Check out the [`style.html`](https://github.com/janraasch/hugo-bearblog/blob/master/layouts/partials/style.html)-file to find out which CSS-styles are applied by default.
 
+
 ## Remixes 🎭
 
 The community has created some interesting variations of Hugo ʕ•ᴥ•ʔ Bear Blog. While the main theme stays true to the minimal Bear Blog philosophy, these remixes experiment with additional features:
@@ -91,18 +107,18 @@ Run the `exampleSite` locally via
 hugo server --source ./exampleSite --themesDir ../..
 ```
 
-In case you want to test functionalities and have to use hugo commands you'll have to append ´--source ./exampleSite --themesDir ../..´ to them.
+In case you want to test functionalities and have to use hugo commands you'll have to append `--source ./exampleSite --themesDir ../..` to them.
 
 For example:
 
 ```bash
-hugo new blog/post.md --source ./exampleSite --themesDir ../..
+hugo new blog/my-new-post.md --source ./exampleSite --themesDir ../..
 ```
 
 Same thing for pages:
 
 ```bash
-hugo new page.md  --source ./exampleSite --themesDir ../..
+hugo new my-new-page.md  --source ./exampleSite --themesDir ../..
 ```
 
 ## Special Thanks 🎁

--- a/README.md
+++ b/README.md
@@ -32,21 +32,6 @@ For more information, read the official [setup guide][hugo-setup-guide] of Hugo.
 
 Please check out the [hugo.toml](https://github.com/janraasch/hugo-bearblog/blob/master/exampleSite/hugo.toml) included in the [exampleSite](https://github.com/janraasch/hugo-bearblog/tree/master/exampleSite) of this theme.
 
-### Post Navigation Setting
-
-In case a user ends up reading more than one blog post, to read another they are forced to
-to go to the `/blog` page.
-
-By enabling, in `hugo.toml`:
-
-```toml
-[params]
-    enablePostNavigator = true
-```
-
-It adds a navigator, at the end of the blog post, so that the user can go to the next
-or previous post without having to go back to the `/blog` page.
-
 ## Content & structure
 
 ### Starting fresh
@@ -78,7 +63,6 @@ hugo new blog/my-new-post.md
 ### Adding your branding / colors / css
 
 Add a `custom_head.html`-file to your `layouts/partials`-directory. In there you may add a `<style>`-tag, *or* you may add a `<link>`-tag referencing your own `custom.css` (in case you prefer to have a separate `.css`-file). Check out the [`style.html`](https://github.com/janraasch/hugo-bearblog/blob/master/layouts/partials/style.html)-file to find out which CSS-styles are applied by default.
-
 
 ## Remixes 🎭
 
@@ -112,13 +96,13 @@ In case you want to test functionalities and use hugo commands, in the root dire
 For example:
 
 ```bash
-hugo new blog/my-new-post.md --source ./exampleSite --themesDir ../..
+hugo new blog/post.md --source ./exampleSite --themesDir ../..
 ```
 
 Same thing for pages:
 
 ```bash
-hugo new my-new-page.md  --source ./exampleSite --themesDir ../..
+hugo new page.md  --source ./exampleSite --themesDir ../..
 ```
 
 ## Special Thanks 🎁

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Please check out the [hugo.toml](https://github.com/janraasch/hugo-bearblog/blob
 
 ### Post Navigation Setting
 
-In case the user ends up reading more than one blog post, in order to read another they have
+In case a user ends up reading more than one blog post, to read another they are forced to
 to go to the `/blog` page.
 
 By enabling, in `hugo.toml`:
@@ -44,8 +44,8 @@ By enabling, in `hugo.toml`:
     enablePostNavigator = true
 ```
 
-It adds a navigator, at the end of the blog post content, so that the user can go to the next
-or previous post.
+It adds a navigator, at the end of the blog post, so that the user can go to the next
+or previous post without having to go back to the `\blog` page.
 
 ## Content & structure
 
@@ -107,7 +107,7 @@ Run the `exampleSite` locally via
 hugo server --source ./exampleSite --themesDir ../..
 ```
 
-In case you want to test functionalities and have to use hugo commands you'll have to append `--source ./exampleSite --themesDir ../..` to them.
+In case you want to test functionalities and use hugo commands, in the root directory, you'll have to append `--source ./exampleSite --themesDir ../..` to them.
 
 For example:
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ By enabling, in `hugo.toml`:
 ```
 
 It adds a navigator, at the end of the blog post, so that the user can go to the next
-or previous post without having to go back to the `\blog` page.
+or previous post without having to go back to the `/blog` page.
 
 ## Content & structure
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,20 @@ Run the `exampleSite` locally via
 hugo server --source ./exampleSite --themesDir ../..
 ```
 
+In case you want to test functionalities and have to use hugo commands you'll have to append ´--source ./exampleSite --themesDir ../..´ to them.
+
+For example:
+
+```bash
+hugo new blog/post.md --source ./exampleSite --themesDir ../..
+```
+
+Same thing for pages:
+
+```bash
+hugo new page.md  --source ./exampleSite --themesDir ../..
+```
+
 ## Special Thanks 🎁
 
 A special thank you goes out to [Herman](https://herman.bearblog.dev), for creating the original [ʕ•ᴥ•ʔ Bear Blog](https://bearblog.dev/).

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -50,3 +50,12 @@ ignoreErrors = ["error-disable-taxonomy"]
   # for details. An example TOML config that uses [ISO
   # 8601](https://en.wikipedia.org/wiki/ISO_8601) format:
   # dateFormat = "2006-01-02"
+
+# Configure markup highlighter to match "Bearblog" aesthetics, see 
+# https://gohugo.io/configuration/markup/#highlight
+[markup]
+  [markup.highlight]
+    style = 'friendly'
+    lineNos = true
+    lineNumbersInTable = false
+    codeFences = true

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -44,6 +44,11 @@ ignoreErrors = ["error-disable-taxonomy"]
   # You can turn it off, but we would really appreciate if you don’t :-).
   # hideMadeWithLine = true
 
+  # By default, if you want to read more than one blog post you have to always go
+  # back to the /blog page.
+  # By enabling this feature each blog post will have at the end a navigator
+  # enablePostNavigator = true
+
   # By default, this theme displays dates with a format like "02 Jan, 2006", but
   # you can customize it by setting the `dateFormat` param in your site's config
   # file. See [Hugo's Format function docs](https://gohugo.io/functions/format/)
@@ -51,7 +56,7 @@ ignoreErrors = ["error-disable-taxonomy"]
   # 8601](https://en.wikipedia.org/wiki/ISO_8601) format:
   # dateFormat = "2006-01-02"
 
-# Configure markup highlighter to match "Bearblog" aesthetics, see 
+# Configure markup highlighter to match "Bearblog" aesthetics, see
 # https://gohugo.io/configuration/markup/#highlight
 [markup]
   [markup.highlight]

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -13,7 +13,9 @@
   {{ .Content }}
 </content>
 
+{{ if (.Param "enablePostNavigator")}}
 {{- partial "post_navigator.html" . -}}
+{{ end }}
 
 <p>
   {{ range (.GetTerms "tags") }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -12,53 +12,8 @@
 <content>
     {{ .Content }}
 </content>
-<!--
-     Tenho que arranjar os links dos posts...
-     Colocar uma opção que dê toggle nesta situação.
 
-     Dá fetch dos posts todos,
-     [a,b,c,d]
-     arranja um apontador para o imediatamente a seguir e
-     o imediatamente atrás.
-
-
-     {{ if not .Data.Singular }}
-     <small>
-     <div>
-     {{ range .Site.Taxonomies.tags }}
-     <a href="{{ .Page.Permalink }}">#{{ .Page.Title }}</a>&nbsp;
-     {{ end }}
-     </div>
-     </small>
-     {{ end }}
-
--->
-
-<div style="font-size:0.8em;display:flex;gap:16px;justify-content:center;">
-    <p>
-        {{ if .PrevInSection }}
-        <a href="{{ .PrevInSection.Permalink }}"><< Previous Post</a>
-        {{ else }}
-        <p><strike><< Previous Post</strike></p>
-        {{ end }}
-    </p>
-    <p>|</p>
-    <p>
-        {{ if .NextInSection }}
-        <a href="{{ .NextInSection.Permalink }}">Next Post >></a>
-        {{ else }}
-        <p><strike>Next Post >></strike></p>
-        {{ end }}
-    </p>
-</div>
-
-<!--
-     <div style="font-size:0.8em;display:flex;gap:16px;justify-content:center;">
-     <p><< Previous Post</p>
-     <p>|</p>
-     <p>Next Post >></p>
-     </div>
--->
+{{- partial "post_navigator.html" . -}}
 
 <p>
   {{ range (.GetTerms "tags") }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -3,15 +3,63 @@
 <h1>{{ .Title }}</h1>
 <p>
   <i>
-    <time datetime='{{ .Date.Format "2006-01-02" }}'>
-      {{ .Date.Format (default "02 Jan, 2006" .Site.Params.dateFormat) }}
-    </time>
+      <time datetime='{{ .Date.Format "2006-01-02" }}'>
+          {{ .Date.Format (default "02 Jan, 2006" .Site.Params.dateFormat) }}
+      </time>
   </i>
 </p>
 {{ end }}{{ end }}
 <content>
-  {{ .Content }}
+    {{ .Content }}
 </content>
+<!--
+     Tenho que arranjar os links dos posts...
+     Colocar uma opção que dê toggle nesta situação.
+
+     Dá fetch dos posts todos,
+     [a,b,c,d]
+     arranja um apontador para o imediatamente a seguir e
+     o imediatamente atrás.
+
+
+     {{ if not .Data.Singular }}
+     <small>
+     <div>
+     {{ range .Site.Taxonomies.tags }}
+     <a href="{{ .Page.Permalink }}">#{{ .Page.Title }}</a>&nbsp;
+     {{ end }}
+     </div>
+     </small>
+     {{ end }}
+
+-->
+
+<div style="font-size:0.8em;display:flex;gap:16px;justify-content:center;">
+    <p>
+        {{ if .PrevInSection }}
+        <a href="{{ .PrevInSection.Permalink }}"><< Previous Post</a>
+        {{ else }}
+        <p><strike><< Previous Post</strike></p>
+        {{ end }}
+    </p>
+    <p>|</p>
+    <p>
+        {{ if .NextInSection }}
+        <a href="{{ .NextInSection.Permalink }}">Next Post >></a>
+        {{ else }}
+        <p><strike>Next Post >></strike></p>
+        {{ end }}
+    </p>
+</div>
+
+<!--
+     <div style="font-size:0.8em;display:flex;gap:16px;justify-content:center;">
+     <p><< Previous Post</p>
+     <p>|</p>
+     <p>Next Post >></p>
+     </div>
+-->
+
 <p>
   {{ range (.GetTerms "tags") }}
   <a href="{{ .Permalink }}">#{{ .LinkTitle }}</a>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -3,14 +3,14 @@
 <h1>{{ .Title }}</h1>
 <p>
   <i>
-      <time datetime='{{ .Date.Format "2006-01-02" }}'>
-          {{ .Date.Format (default "02 Jan, 2006" .Site.Params.dateFormat) }}
-      </time>
+    <time datetime='{{ .Date.Format "2006-01-02" }}'>
+      {{ .Date.Format (default "02 Jan, 2006" .Site.Params.dateFormat) }}
+    </time>
   </i>
 </p>
 {{ end }}{{ end }}
 <content>
-    {{ .Content }}
+  {{ .Content }}
 </content>
 
 {{- partial "post_navigator.html" . -}}

--- a/layouts/partials/post_navigator.html
+++ b/layouts/partials/post_navigator.html
@@ -1,5 +1,3 @@
-{{ if (.Param "enablePostNavigator")}}
-{{if eq .Type "blog" }}
 <div class="post-navigator">
   <p>
     {{ if .PrevInSection }}
@@ -19,5 +17,3 @@
     {{ end }}
   </p>
 </div>
-{{ end }}
-{{ end }}

--- a/layouts/partials/post_navigator.html
+++ b/layouts/partials/post_navigator.html
@@ -1,6 +1,6 @@
 {{ if (.Param "enablePostNavigator")}}
 {{if eq .Type "blog" }}
-<div style="font-size:0.8em;display:flex;gap:16px;justify-content:center;">
+<div class="post-navigator">
   <p>
     {{ if .PrevInSection }}
     <a href="{{ .PrevInSection.Permalink }}">

--- a/layouts/partials/post_navigator.html
+++ b/layouts/partials/post_navigator.html
@@ -1,4 +1,4 @@
-<div class="post-navigator">
+<div style="font-size:0.8em;display:flex;gap:16px;justify-content:center;">
   <p>
     {{ if .PrevInSection }}
     <a href="{{ .PrevInSection.Permalink }}">

--- a/layouts/partials/post_navigator.html
+++ b/layouts/partials/post_navigator.html
@@ -1,0 +1,21 @@
+{{ if (.Param "enablePostNavigator")}}
+{{if eq .Type "blog" }}
+<div style="font-size:0.8em;display:flex;gap:16px;justify-content:center;">
+    <p>
+        {{ if .PrevInSection }}
+        <a href="{{ .PrevInSection.Permalink }}"><< Previous Post</a>
+        {{ else }}
+        <strike><< Previous Post</strike>
+        {{ end }}
+    </p>
+    <p>|</p>
+    <p>
+        {{ if .NextInSection }}
+        <a href="{{ .NextInSection.Permalink }}">Next Post >></a>
+        {{ else }}
+        <strike>Next Post >></strike>
+        {{ end }}
+    </p>
+</div>
+{{ end }}
+{{ end }}

--- a/layouts/partials/post_navigator.html
+++ b/layouts/partials/post_navigator.html
@@ -1,21 +1,23 @@
 {{ if (.Param "enablePostNavigator")}}
 {{if eq .Type "blog" }}
 <div style="font-size:0.8em;display:flex;gap:16px;justify-content:center;">
-    <p>
-        {{ if .PrevInSection }}
-        <a href="{{ .PrevInSection.Permalink }}"><< Previous Post</a>
+  <p>
+    {{ if .PrevInSection }}
+    <a href="{{ .PrevInSection.Permalink }}">
+      << Previous Post</a>
         {{ else }}
-        <strike><< Previous Post</strike>
-        {{ end }}
-    </p>
-    <p>|</p>
-    <p>
-        {{ if .NextInSection }}
-        <a href="{{ .NextInSection.Permalink }}">Next Post >></a>
-        {{ else }}
-        <strike>Next Post >></strike>
-        {{ end }}
-    </p>
+        <strike>
+          << Previous Post</strike>
+            {{ end }}
+  </p>
+  <p>|</p>
+  <p>
+    {{ if .NextInSection }}
+    <a href="{{ .NextInSection.Permalink }}">Next Post >></a>
+    {{ else }}
+    <strike>Next Post >></strike>
+    {{ end }}
+  </p>
 </div>
 {{ end }}
 {{ end }}

--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -159,4 +159,11 @@
     color: var(--visited-color);
   }
 
+  /* Post navigator styles */
+  .post-navigator {
+    font-size: 0.8em;
+    display: flex;
+    gap: 16px;
+    justify-content: center;
+  }
 </style>

--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -159,11 +159,4 @@
     color: var(--visited-color);
   }
 
-  /* Post navigator styles */
-  .post-navigator {
-    font-size: 0.8em;
-    display: flex;
-    gap: 16px;
-    justify-content: center;
-  }
 </style>


### PR DESCRIPTION
This feature implements an opt-in component that, when enabled, adds a navigator at the end of each blog post; so that the users are not forced to go back to the `/blog` page after reading each post.

It implements the feature mentioned in #118 

## Explanation for the Setting Placement

I decided to put this feature under `params` in the `hugo.toml` file, given that it is similar to `hideMadeWithLine`.

## Implementation

The component in question follows the same strategies as the rest of the code:
- the new feature is in `layouts/partials/post_navigator.html`
- and it's implemented in `layouts/partials/single.html`

## Final Note

I’ve added a summary of this feature in both the `README.md` and `hugo.toml` files. Additionally, I’ve included a brief explanation in the Development section to clarify how a developer should execute hugo commands from the root directory of this project.

I’m open to any changes or discussions.