### PR TITLE
fix: extend code block background when scrolling horizontally

### DIFF
--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -132,6 +132,12 @@
     overflow-x: auto;
   }
 
+  .highlight pre,
+  .code pre {
+    min-width: 100%;
+    width: max-content;
+  }
+
   /* blog post list */
   ul.blog-posts {
     list-style-type: none;


### PR DESCRIPTION
## Summary

- Adds `min-width: 100%; width: max-content` to `.highlight pre` and `.code pre`
- Fixes the code block background not extending when scrolling horizontally on narrow viewports
- Ensures the background also fills the full container width when content is short

## Problem

On small screens, when a code block contains a line longer than the viewport width, Hugo's chroma highlighter sets a background color on the `<pre>` element. With `overflow-x: auto` on `.highlight`, the scrollable area is created — but the `<pre>` only fills the visible container width. Scrolling right reveals text on a transparent/white background.

## Fix

```css
.highlight pre,
.code pre {
  min-width: 100%;
  width: max-content;
}
```

`min-width: 100%` ensures the `<pre>` always fills the container for short content. `width: max-content` allows it to grow beyond the container for long lines. The browser resolves to `max(min-width, width)`, handling both cases correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)